### PR TITLE
Fix makefile (also install VarrGroup.h)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,13 +3,13 @@
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES = libTreeWrapper.la
-libTreeWrapper_la_SOURCES = src/TreeWrapper.cc src/Leaf.cc src/Brancher.cc src/TreeGroup.cc src/TreeWrapperAccessor.cc interface/TreeWrapper.h interface/Leaf.h interface/TreeGroup.h interface/Brancher.h interface/Resetter.h interface/TreeWrapperAccessor.h
+libTreeWrapper_la_SOURCES = src/TreeWrapper.cc src/Leaf.cc src/Brancher.cc src/TreeGroup.cc src/TreeWrapperAccessor.cc interface/TreeWrapper.h interface/Leaf.h interface/TreeGroup.h interface/VarrGroup.h interface/Brancher.h interface/Resetter.h interface/TreeWrapperAccessor.h
 libTreeWrapper_la_LIBADD  = @ROOTLIBS@ @ROOTAUXLIBS@
 
 AM_CPPFLAGS             = @AM_CPPFLAGS@ -Iinterface -I@ROOTINCDIR@
 AM_LDFLAGS              = -L@ROOTLIBDIR@
 
-include_HEADERS = interface/TreeWrapper.h interface/Leaf.h interface/TreeGroup.h interface/Brancher.h interface/Resetter.h interface/TreeWrapperAccessor.h
+include_HEADERS = interface/TreeWrapper.h interface/Leaf.h interface/TreeGroup.h interface/VarrGroup.h interface/Brancher.h interface/Resetter.h interface/TreeWrapperAccessor.h
 
 COMMON_DOC_FLAGS = --report --output html $(libTreeWrapper_la_SOURCES)
 

--- a/interface/VarrGroup.h
+++ b/interface/VarrGroup.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <functional>
 
 #include "TreeWrapperAccessor.h"
 #include "Brancher.h"


### PR DESCRIPTION
I forgot this in #1 , I didn't notice because I built inside CMSSW, but @alesaggio ran into it when generating a plotter after updating to the most recent TreeWrapper.
I added the functional include because gcc 7.2 complains about this not being included automatically any more (5.3 was fine with it).