### PR TITLE
Don't crash when trying to read a missing branch

### DIFF
--- a/interface/Leaf.h
+++ b/interface/Leaf.h
@@ -126,7 +126,7 @@ namespace ROOT {
                     }
 
 
-                    if (m_tree.entry() != -1) {
+                    if ( m_branch && (m_tree.entry() != -1) ) {
                         // A global GetEntry already happened in the tree
                         // Call GetEntry directly on the Branch to catch up
                         m_branch->GetEntry(m_tree.entry());


### PR DESCRIPTION
TTreeWrapper::getEntry does not try to read missing branches (cfr. the "cleaning" code there), but if the plotter crashes in the constructor, that doesn't help ;-) .
The user is still responsible not to actually use the value, but that's why there's a warning... I don't think we can protect against actually accessing the invalid reference in another way, unfortunately. Maybe we should make the warning a bit louder?