### PR TITLE
Fix gcc7 warnings

### DIFF
--- a/interface/Brancher.h
+++ b/interface/Brancher.h
@@ -22,6 +22,7 @@ namespace ROOT {
 struct Brancher {
     public:
         virtual void operator()(const std::string&, TTree* tree) = 0;
+        virtual ~Brancher() {}
 };
 
 template <typename T>

--- a/interface/Leaf.h
+++ b/interface/Leaf.h
@@ -126,7 +126,7 @@ namespace ROOT {
                     }
 
 
-                    if ( m_branch && (m_tree.entry() != -1) ) {
+                    if ( m_branch && (m_tree.entry() != uint64_t(-1)) ) {
                         // A global GetEntry already happened in the tree
                         // Call GetEntry directly on the Branch to catch up
                         m_branch->GetEntry(m_tree.entry());

--- a/interface/Resetter.h
+++ b/interface/Resetter.h
@@ -12,6 +12,7 @@
 struct Resetter {
     public:
         virtual void reset() = 0;
+        virtual ~Resetter() {}
 };
 
 /* Base class for `reset` functionnality.


### PR DESCRIPTION
All rather straightforward (unless I overlooked something): missing virtual destructors in interfaces and a signed-unsigned comparison